### PR TITLE
Remove repeated of c.txt in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ For the consumer of the library it will look like all the folders are merged fro
 /*
 -- b.txt
 -- c.txt
--- c.txt
 -- d.txt
 -- sub-dir
     |


### PR DESCRIPTION
Remove duplicate `c.txt` in README example.